### PR TITLE
fail2ban : remove jail sshd-ddos / postfix_sasl

### DIFF
--- a/conf/monitorix.conf
+++ b/conf/monitorix.conf
@@ -588,9 +588,9 @@ secure_log_date_format = %b %e
         <desc>
                 0 = [recidive], [pam-generic]
                 1 = [yunohost]
-                2 = [postfix], [postfix-sasl], [dovecot]
+                2 = [postfix], [dovecot]
                 3 = [nginx-http-auth]
-                4 = [sshd], [sshd-ddos]
+                4 = [sshd]
                 5 = __F2B_ADDITIONAL_JAIL__
         </desc>
         graphs_per_row = 2


### PR DESCRIPTION
This 2 jails doesn't exist by default.
This 2 jail are generated a lot of lines in /var/log/fail2ban.log.
 fail2ban.transmitter    [596]: WARNING Command ['status', 'postfix-sasl'] has failed. Received UnknownJailException('postfix-sasl')
 fail2ban.transmitter    [596]: WARNING Command ['status', 'sshd-ddos'] has failed. Received UnknownJailException('sshd-ddos')